### PR TITLE
Fix NZB detection for easynews-as-indexer

### DIFF
--- a/src/services/newznab.js
+++ b/src/services/newznab.js
@@ -435,8 +435,27 @@ function isLikelyNzb(url) {
     normalized.includes('mode=getnzb') ||
     normalized.includes('t=getnzb') ||
     normalized.includes('action=getnzb') ||
-    /\bgetnzb\b/.test(normalized)
+    normalized.includes('t=get&id=') ||
+    /\bgetnzb\b/.test(normalized) ||
+    hasDownloadLikeQuery(url)
   );
+}
+
+function hasDownloadLikeQuery(url) {
+  try {
+    const parsed = new URL(url);
+    const tParam = (parsed.searchParams.get('t') || '').toLowerCase();
+    if (tParam === 'get' || tParam === 'getfile' || tParam === 'download') {
+      return true;
+    }
+    const ext = (parsed.searchParams.get('ext') || '').toLowerCase();
+    if (ext && /^\.?(nzb|mkv|mp4|ts|avi|mp3|flac|rar|7z)$/.test(ext.startsWith('.') ? ext : `.${ext}`)) {
+      return true;
+    }
+  } catch (_) {
+    // ignore URL parse errors
+  }
+  return false;
 }
 
 function normalizeNewznabItem(item, config, { filterNzbOnly = true } = {}) {

--- a/src/utils/connectionTests.js
+++ b/src/utils/connectionTests.js
@@ -286,12 +286,16 @@ async function testNewznabSearch(values) {
     rawQuery: query,
     tokens: [],
   };
+  const filterNzbOnly = values?.NEWZNAB_FILTER_NZB_ONLY === undefined
+    ? true
+    : parseBoolean(values.NEWZNAB_FILTER_NZB_ONLY);
   logNewznabDebug('Running admin Newznab test search', {
     plan,
     indexers: configs.map((config) => ({ id: config.id, name: config.displayName, endpoint: config.endpoint })),
+    filterNzbOnly,
   });
   const result = await searchNewznabIndexers(plan, configs, {
-    filterNzbOnly: true,
+    filterNzbOnly,
     debug: NEWZNAB_DEBUG_ENABLED,
     label: '[NEWZNAB][TEST]',
   });


### PR DESCRIPTION
When testing a fix for easynews-as-indexer, I discovered that the NZBs returned from EAS were not being detected when `Filter to NZB URLs Only` was enabled, and worse, the toggle for `Filter to NZB URLs Only` was broken in the admin UI, so it **looked** as if EAS was always broken.

This PR fixes both, and EAS results will be treated as NZBs even when `Filter to NZB URLs Only` is true.

D