### PR TITLE
Add stream visibility filter

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -266,10 +266,10 @@
             <label>Stream Visibility
               <select name="NZB_HEALTH_VISIBILITY">
                 <option value="all">Show all results</option>
-                <option value="hide_bad">Hide known-bad results</option>
-                <option value="instant_only">Instant &amp; verified only</option>
+                <option value="hide_bad">Hide known-bad results (show unknown results)</option>
+                <option value="good_only">Healthy results only</option>
               </select>
-              <span class="field-hint">Show everything, hide unhealthy releases, or show only instant/verified releases.</span>
+              <span class="field-hint">Show everything, hide unhealthy releases, or keep only healthy ones.</span>
             </label>
           </div>
         </section>

--- a/server.js
+++ b/server.js
@@ -466,7 +466,7 @@ const MAX_NEWZNAB_INDEXERS = newznabService.MAX_NEWZNAB_INDEXERS;
 const NEWZNAB_NUMBERED_KEYS = newznabService.NEWZNAB_NUMBERED_KEYS;
 const POSITIVE_HEALTH_STATUSES = new Set(['verified', 'elf-verified', 'healthy', 'good', 'ok', 'passed']);
 const NEGATIVE_HEALTH_STATUSES = new Set(['blocked', 'fetch-error', 'error']);
-const HEALTH_VISIBILITY_MODES = new Set(['all', 'hide_bad', 'instant_only']);
+const HEALTH_VISIBILITY_MODES = new Set(['all', 'hide_bad', 'good_only']);
 
 let NZB_HEALTH_VISIBILITY = resolveHealthVisibilityEnv();
 
@@ -1875,13 +1875,13 @@ async function streamHandler(req, res) {
         const hasPositiveStatus = normalizedTriageStatus ? POSITIVE_HEALTH_STATUSES.has(normalizedTriageStatus) : false;
         const hasNegativeStatus = normalizedTriageStatus ? NEGATIVE_HEALTH_STATUSES.has(normalizedTriageStatus) : false;
         switch (NZB_HEALTH_VISIBILITY) {
-          case 'instant_only':
-            if (!isInstant && !hasPositiveStatus) {
+          case 'hide_bad':
+            if (hasNegativeStatus) {
               return;
             }
             break;
-          case 'hide_bad':
-            if (hasNegativeStatus) {
+          case 'good_only':
+            if (!hasPositiveStatus) {
               return;
             }
             break;


### PR DESCRIPTION
This 100% certified bug-free PR adds a dropdown to the filtering section, allowing the user to choose to show all results (the default and current behaviour), to remove known-bad results (still showing unknowns), or to show only known-good results.