### PR TITLE
feat: add per-indexer pagination support for Newznab

### DIFF
--- a/admin/app.js
+++ b/admin/app.js
@@ -33,7 +33,7 @@
   let newznabPresets = [];
 
   const MAX_NEWZNAB_INDEXERS = 20;
-  const NEWZNAB_SUFFIXES = ['ENDPOINT', 'API_KEY', 'API_PATH', 'NAME', 'INDEXER_ENABLED', 'PAID'];
+  const NEWZNAB_SUFFIXES = ['ENDPOINT', 'API_KEY', 'API_PATH', 'NAME', 'INDEXER_ENABLED', 'PAID', 'PAGINATE'];
 
   const managerSelect = configForm.querySelector('select[name="INDEXER_MANAGER"]');
   const newznabList = document.getElementById('newznab-indexers-list');
@@ -395,6 +395,10 @@
           <label class="checkbox">
             <input type="checkbox" data-field="PAID" />
             <span>Paid / Health-ready</span>
+          </label>
+          <label class="checkbox" title="Fetch up to 5 pages of results (slower but more results)">
+            <input type="checkbox" data-field="PAGINATE" />
+            <span>Paginate</span>
           </label>
         </div>
         <div class="row-controls">


### PR DESCRIPTION
Added a "Paginate" checkbox next to "Paid/Health Ready" for each indexer. It's set to 5 pages for 500 results. This way, users can add pagination to a usenet indexer if that indexer benefits from pagination.

<img width="1022" height="379" alt="Screenshot 2025-11-29 175548" src="https://github.com/user-attachments/assets/8f0063c5-aa29-4d1f-a1da-572603bcb6c4" />

### CODE CHANGES

`admin/app.js:` Added "Paginate" checkbox to the dynamically generated Newznab rows

`src/indexers/newznab.js:` Updated `fetchIndexerResults` to check for the` isPaginated` flag. If true, loops through the requests until it hits 5 pages or runs out of results.

### TESTS

Ran locally with pagination vs my current self hosted usenetstreamer instance running version 1.5.0 with no pagination available.

### EXAMPLE SEARCH:

Below example is _Interstellar (2014)_

### 1st image is local test with Pagination. 2nd image is my current VPS running v1.5.0. 

### 222 results vs 77 respectively.
<img width="1198" height="377" alt="Screenshot 2025-11-29 175329" src="https://github.com/user-attachments/assets/deec1b0a-be0d-4588-8d64-c2ab33da84af" />

<img width="1206" height="447" alt="Screenshot 2025-11-29 175337" src="https://github.com/user-attachments/assets/2ba057ec-a1f4-41a0-b142-1e0a062a730f" />