### PR TITLE
Add User-Agent Configuration with Per-Service Overrides

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,17 @@ INDEXER_MANAGER_INDEXERS=-1  # Prowlarr: use -1 for all Usenet indexers; NZBHydr
 ADDON_BASE_URL=https://your-addon-domain  # Need to be publicly accessible and secure (HTTPS)
 ADDON_SHARED_SECRET=super-secret-token  # Required if you want to lock the addon; manifest/stream endpoints live under /<token>/...
 
+# User-Agent customization (Priority: per-service > global > default)
+# Default when not set: UsenetStreamer/<version> (e.g., UsenetStreamer/1.6.0)
+#ADDON_USER_AGENT_GLOBAL="MyGlobalAgent/1.0"
+#ADDON_USER_AGENT_EASYNEWS="EasynewsAgent/1.0"
+#ADDON_USER_AGENT_INDEXER="IndexerAgent/1.0"
+#ADDON_USER_AGENT_NEWZNAB="NewznabAgent/1.0"
+#ADDON_USER_AGENT_NZBDAV="NzbdavAgent/1.0"
+#ADDON_USER_AGENT_SPECIALMETADATA="SpecialMetaAgent/1.0"
+#ADDON_USER_AGENT_TMDB="TmdbAgent/1.0"
+# Note: ADDON_USER_AGENT_TRIAGE applies when downloading NZBs from indexers (HTTP), but not when connecting to your Usenet provider for health checks (NNTP protocol)
+#ADDON_USER_AGENT_TRIAGE="TriageAgent/1.0"
 
 # Result sorting defaults
 #NZB_SORT_MODE=quality_then_size  # Options: quality_then_size, language_quality_size

--- a/README.md
+++ b/README.md
@@ -178,6 +178,26 @@ The dashboard is protected by the same shared secret as the manifest. Rotate it 
 
 See `.env.example` for the complete list and defaults.
 
+### 🕵️ User-Agent configuration
+
+You can control outbound `User-Agent` headers the addon sends to external services. There are two levels:
+
+- Specific per-service env vars (highest priority):
+  - `ADDON_USER_AGENT_EASYNEWS` — Easynews requests
+  - `ADDON_USER_AGENT_INDEXER` — Indexer manager requests (Prowlarr/NZBHydra)
+  - `ADDON_USER_AGENT_NEWZNAB` — Direct Newznab indexer requests
+  - `ADDON_USER_AGENT_NZBDAV` — NZBDav HEAD/stream proxy requests
+  - `ADDON_USER_AGENT_SPECIALMETADATA` - Special Metadata
+  - `ADDON_USER_AGENT_TMDB` — TMDB API requests
+  - `ADDON_USER_AGENT_TRIAGE` — Triage NZB downloads
+
+- A global env var:
+  - `ADDON_USER_AGENT_GLOBAL` (fallback if the specific per-service var is not set) — applies to the services that support per-service env vars.
+
+- Default (when not set): `UsenetStreamer/<version>` (e.g., `UsenetStreamer/1.6.0`)
+
+**Note:** `ADDON_USER_AGENT_TRIAGE` controls HTTP requests when downloading NZB files from indexers. Direct NNTP connections to your Usenet provider (for health checks) don't support User-Agent headers.
+
 ---
 
 ## 🧠 Advanced Capabilities

--- a/src/services/easynews/index.js
+++ b/src/services/easynews/index.js
@@ -1,4 +1,4 @@
-const axios = require('axios');
+const externalApi = require('../../utils/externalApi');
 const { stripTrailingSlashes, toBoolean } = require('../../utils/config');
 
 const EASYNEWS_BASE_URL = 'https://members.easynews.com';
@@ -17,12 +17,6 @@ const DISALLOWED_EXTENSIONS = new Set(['.rar', '.zip', '.exe', '.jpg', '.png']);
 const ALLOWED_VIDEO_EXTENSIONS = new Set(['.mkv', '.mp4', '.m4v', '.avi', '.ts', '.mov', '.wmv', '.mpg', '.mpeg', '.flv', '.webm']);
 const EASYNEWS_INDEXER_ID = 'easynews';
 const EASYNEWS_INDEXER_NAME = 'Easynews';
-
-const httpClient = axios.create({
-  baseURL: EASYNEWS_BASE_URL,
-  timeout: DEFAULT_TIMEOUT_MS,
-  validateStatus: (status) => status >= 200 && status < 500,
-});
 
 let EASYNEWS_ENABLED = false;
 let EASYNEWS_USERNAME = '';
@@ -73,9 +67,6 @@ function buildAuthConfig(override = null) {
     auth: {
       username,
       password,
-    },
-    headers: {
-      'User-Agent': 'UsenetStreamer-Easynews/1.0'
     }
   };
 }
@@ -420,8 +411,14 @@ async function fetchSearchResults(query, authOverride = null) {
   params.set('s1d', '-');
   params.append('fty[]', 'VIDEO');
 
-  const requestUrl = `/2.0/search/solr-search/?${params.toString()}`;
-  const response = await httpClient.get(requestUrl, buildAuthConfig(authOverride));
+  const requestUrl = `${EASYNEWS_BASE_URL}/2.0/search/solr-search/?${params.toString()}`;
+  
+  const response = await externalApi.get(requestUrl, {
+    service: 'easynews',
+    ...buildAuthConfig(authOverride),
+    timeout: DEFAULT_TIMEOUT_MS,
+    validateStatus: (status) => status >= 200 && status < 500
+  });
   if (response.status === 401 || response.status === 403) {
     throw new Error('Easynews rejected credentials');
   }
@@ -529,11 +526,13 @@ async function downloadEasynewsNzb(payloadToken) {
     ...(authConfig.headers || {}),
     'Content-Type': 'application/x-www-form-urlencoded',
   };
-  const response = await httpClient.post('/2.0/api/dl-nzb', form.toString(), {
+  const response = await externalApi.post(`${EASYNEWS_BASE_URL}/2.0/api/dl-nzb`, form.toString(), {
+    service: 'easynews',
     ...authConfig,
     headers: mergedHeaders,
     responseType: 'arraybuffer',
     timeout: EASYNEWS_NZB_DOWNLOAD_TIMEOUT_MS,
+    validateStatus: (status) => status >= 200 && status < 500
   });
   if (response.status !== 200) {
     throw new Error(`Easynews NZB download failed (${response.status})`);

--- a/src/services/indexer.js
+++ b/src/services/indexer.js
@@ -1,5 +1,6 @@
 // Indexer service - Prowlarr and NZBHydra integration
-const axios = require('axios');
+const externalApi = require('../utils/externalApi');
+
 const { getPublishMetadataFromResult, areReleasesWithinDays } = require('../utils/publishInfo');
 
 // Configuration (runtime reloadable)
@@ -90,7 +91,8 @@ async function executeProwlarrSearch(plan) {
   const requestUrl = `${INDEXER_MANAGER_BASE_URL}/api/v1/search`;
   const fullUrl = serializedParams ? `${requestUrl}?${serializedParams}` : requestUrl;
   console.log('[PROWLARR] Requesting search', { url: fullUrl });
-  const response = await axios.get(fullUrl, {
+  const response = await externalApi.get(fullUrl, {
+    service: 'indexer',
     headers: { 'X-Api-Key': INDEXER_MANAGER_API_KEY },
     timeout: 60000
   });
@@ -316,7 +318,8 @@ function normalizeHydraResults(data) {
 
 async function executeNzbhydraSearch(plan) {
   const params = buildHydraSearchParams(plan);
-  const response = await axios.get(`${INDEXER_MANAGER_BASE_URL}/api`, {
+  const response = await externalApi.get(`${INDEXER_MANAGER_BASE_URL}/api`, {
+    service: 'indexer',
     params,
     timeout: 60000
   });

--- a/src/services/newznab.js
+++ b/src/services/newznab.js
@@ -1,4 +1,4 @@
-const axios = require('axios');
+const externalApi = require('../utils/externalApi');
 const { parseStringPromise: parseXmlString } = require('xml2js');
 const { stripTrailingSlashes } = require('../utils/config');
 
@@ -505,7 +505,8 @@ async function fetchIndexerResults(config, plan, options) {
     console.log(`${logPrefix}[SEARCH][REQ]`, { url: requestUrl, params: safeParams });
   }
 
-  const response = await axios.get(requestUrl, {
+  const response = await externalApi.get(requestUrl, {
+    service: 'newznab',
     params,
     timeout: options.timeoutMs || DEFAULT_REQUEST_TIMEOUT_MS,
     responseType: 'text',
@@ -627,7 +628,8 @@ async function testNewznabCaps(config, options = {}) {
     console.log(`${logPrefix}[REQ]`, { url: requestUrl, params: { ...params, apikey: maskApiKey(params.apikey) } });
   }
 
-  const response = await axios.get(requestUrl, {
+  const response = await externalApi.get(requestUrl, {
+    service: 'newznab',
     params,
     timeout: options.timeoutMs || 12000,
     responseType: 'text',

--- a/src/services/specialMetadata.js
+++ b/src/services/specialMetadata.js
@@ -1,5 +1,5 @@
 // Special metadata service - External catalog provider integration
-const axios = require('axios');
+const externalApi = require('../utils/externalApi');
 const { cleanSpecialSearchTitle, stripTrailingSlashes } = require('../utils/parsers');
 
 // Configuration
@@ -34,7 +34,7 @@ async function fetchSpecialMetadata(identifier) {
   const requestUrl = `${trimmedBase}/stream/movie/${encodeURIComponent(identifier)}.json`;
   console.log('[SPECIAL META] Fetching metadata for external catalog request');
 
-  const response = await axios.get(requestUrl, { timeout: 10000 });
+  const response = await externalApi.get(requestUrl, { service: 'specialmetadata', timeout: 10000 });
   const streams = response.data?.streams;
   const firstTitle = Array.isArray(streams) && streams.length > 0 ? streams[0]?.title : null;
 

--- a/src/services/tmdb.js
+++ b/src/services/tmdb.js
@@ -1,5 +1,5 @@
 // TMDb service - Localized title fetching for improved search
-const axios = require('axios');
+const externalApi = require('../utils/externalApi');
 const https = require('https');
 
 // Disable keep-alive to force fresh connections and avoid stale-socket ECONNRESET
@@ -162,7 +162,8 @@ async function tmdbRequest(endpoint, params = {}) {
 
   for (let attempt = 0; attempt <= TMDB_RETRY_COUNT; attempt++) {
     try {
-      const response = await axios.get(url, {
+      const response = await externalApi.get(url, {
+        service: 'tmdb',
         params,
         headers: {
           'Authorization': `Bearer ${TMDB_API_KEY}`,

--- a/src/services/triage/runner.js
+++ b/src/services/triage/runner.js
@@ -1,4 +1,4 @@
-const axios = require('axios');
+const externalApi = require('../../utils/externalApi');
 const { triageNzbs } = require('./index');
 
 const DEFAULT_TIME_BUDGET_MS = 45000;
@@ -295,13 +295,13 @@ async function triageAndRank(nzbResults, options = {}) {
           abortController.abort();
         }, downloadTimeoutMs);
 
-        const response = await axios.get(downloadUrl, {
+        const response = await externalApi.get(downloadUrl, {
           responseType: 'text',
+          service: 'triage',
           timeout: downloadTimeoutMs,
           signal: abortController.signal,
           headers: {
-            Accept: 'application/x-nzb,text/xml;q=0.9,*/*;q=0.8',
-            'User-Agent': 'UsenetStreamer-Triage',
+            Accept: 'application/x-nzb,text/xml;q=0.9,*/*;q=0.8'
           },
           transitional: { silentJSONParsing: true, forcedJSONParsing: false },
         }).finally(() => {

--- a/src/utils/connectionTests.js
+++ b/src/utils/connectionTests.js
@@ -1,4 +1,4 @@
-const axios = require('axios');
+const externalApi = require('./externalApi');
 const FormData = require('form-data');
 const fs = require('fs');
 const path = require('path');
@@ -79,7 +79,8 @@ async function verifyNzbdavDiagnosticUpload({ baseUrl, apiKey, category }) {
     headers['x-api-key'] = apiKey;
   }
 
-  const response = await axios.post(`${baseUrl}/api`, form, {
+  const response = await externalApi.post(`${baseUrl}/api`, form, {
+    service: 'nzbdav',
     params,
     headers,
     timeout: 15000,
@@ -136,7 +137,8 @@ async function testIndexerConnection(values) {
 
   if (managerType === 'prowlarr') {
     if (!apiKey) throw new Error('API key is required for Prowlarr');
-    const response = await axios.get(`${baseUrl}/api/v1/system/status`, {
+    const response = await externalApi.get(`${baseUrl}/api/v1/system/status`, {
+      service: 'indexer',
       headers: { 'X-Api-Key': apiKey },
       timeout,
       validateStatus: () => true,
@@ -155,7 +157,8 @@ async function testIndexerConnection(values) {
   const params = { t: 'caps', o: 'json' };
   if (apiKey) params.apikey = apiKey;
   
-  const response = await axios.get(`${baseUrl}/api`, {
+    const response = await externalApi.get(`${baseUrl}/api`, {
+    service: 'indexer',
     params,
     timeout,
     validateStatus: () => true,
@@ -203,7 +206,8 @@ async function testNzbdavConnection(values) {
       category: diagnosticCategory,
     });
 
-    const webdavResponse = await axios.request({
+    const webdavResponse = await externalApi.request({
+      service: 'nzbdav',
       method: 'PROPFIND',
       url: `${webdavUrl}/`,
       auth: {
@@ -399,7 +403,8 @@ async function testTmdbConnection(values) {
   
   try {
     // Test the API key by fetching configuration
-    const response = await axios.request({
+    const response = await externalApi.request({
+      service: 'tmdb',
       method: 'GET',
       url: 'https://api.themoviedb.org/3/configuration',
       headers: {

--- a/src/utils/externalApi.js
+++ b/src/utils/externalApi.js
@@ -1,0 +1,78 @@
+const axios = require('axios');
+// Import version from package.json or define a constant
+const ADDON_VERSION = require('../../package.json').version || '1.0.0';
+
+// Get the User-Agent string from environment variables and remove extra spaces
+const globalUa = (process.env.ADDON_USER_AGENT_GLOBAL || '').trim();
+// Define a default User-Agent if none is provided 
+const defaultUa = `UsenetStreamer/${ADDON_VERSION}`;
+// Define the baseline UA to simplify logic. Priority: Global Env Var > Default
+const baselineUa = globalUa || defaultUa;
+
+// Log the baseline UA at startup
+console.log('[USERAGENT] Baseline User-Agent:', baselineUa);
+
+// Initialize a configuration object with the baseline UA
+const config = {
+  headers: { 
+    'User-Agent': baselineUa
+  }
+};
+
+// Create the isolated instance
+const externalApi = axios.create(config);
+
+/**
+ * SMART INTERCEPTOR
+ * This runs automatically before every request to check for service-specific overrides.
+ * 
+ * Services: 
+ *      ADDON_USER_AGENT_GLOBAL
+ *      ADDON_USER_AGENT_EASYNEWS
+ *      ADDON_USER_AGENT_INDEXER
+ *      ADDON_USER_AGENT_NEWZNAB
+ *      ADDON_USER_AGENT_NZBDAV
+ *      ADDON_USER_AGENT_SPECIALMETADATA
+ *      ADDON_USER_AGENT_TMDB
+ *      ADDON_USER_AGENT_TRIAGE 
+ */
+
+externalApi.interceptors.request.use((config) => {
+
+  // Skip the intercept if the caller explicitly provided a custom User-Agent
+  if (config.headers['User-Agent'] && config.headers['User-Agent'] !== baselineUa) {
+    return config;
+  }
+
+  // Check for an explicit service flag (ex: { service: 'easynews' })
+  const service = (config.service || '').toLowerCase().trim();
+
+  // Map the service names to their corresponding env var names
+  const envMap = {
+    easynews: 'ADDON_USER_AGENT_EASYNEWS',
+    indexer:  'ADDON_USER_AGENT_INDEXER',
+    newznab:  'ADDON_USER_AGENT_NEWZNAB',
+    nzbdav:   'ADDON_USER_AGENT_NZBDAV',
+    specialmetadata: 'ADDON_USER_AGENT_SPECIALMETADATA',
+    tmdb:     'ADDON_USER_AGENT_TMDB',
+    triage:   'ADDON_USER_AGENT_TRIAGE'
+  };
+
+  // If the service is recognized, attempt to get its custom UA
+  if (service) {
+    const envVarName = envMap[service];
+    const customUa = envVarName ? (process.env[envVarName] || '').trim() : null;
+    
+    // If a custom UA is found, set it in the headers
+    if (customUa) {
+      config.headers['User-Agent'] = customUa;
+      console.log(`[USERAGENT] Overriding for service: ${service}:`, customUa);
+    }
+  }
+  // Return the modified config
+  return config;
+  // If an error occurs, reject the promise
+}, (error) => Promise.reject(error));
+
+// Export the configured axios instance
+module.exports = externalApi;


### PR DESCRIPTION
This PR adds configurable User-Agent support for all external HTTP requests with per-service customization.

    - Create scoped externalApi with interceptor for User-Agent management
    - Support per-service env vars (EASYNEWS, INDEXER, NEWZNAB, NZBDAV, SPECIALMETADATA, TMDB, TRIAGE)
    - Add global fallback (ADDON_USER_AGENT_GLOBAL)
    - Default to UsenetStreamer/<version> when not configured
    - Convert all services to use a centralized axios instance (externalApi)
    - Document in README and .env.example"
 
### Docker Image Available
For testing before merge, a Docker image is available:
```docker pull ghcr.io/dsmart33/usenetstreamer:user-agent-feature```

While using the docker image, watch the logs:
```docker logs -f usenet-streamer | grep USERAGENT```

Tested:
    - Per-service User-Agent overrides (7 services)
    - Global fallback
    - Default fallback (UsenetStreamer/version)
    - httpbin verification
    - End-to-end Stremio integration

Complete Test Cases:
```
# Create .env for testing all services
cat > .env << 'EOF'
ADDON_BASE_URL=https://your-new-url.trycloudflare.com
ADDON_SHARED_SECRET=test-token
ADDON_USER_AGENT_GLOBAL=TestGlobal/1.0
ADDON_USER_AGENT_EASYNEWS=TestEasynews/1.0
ADDON_USER_AGENT_INDEXER=TestIndexer/1.0
ADDON_USER_AGENT_NEWZNAB=TestNewznab/1.0
ADDON_USER_AGENT_NZBDAV=TestNzbdav/1.0
ADDON_USER_AGENT_SPECIALMETADATA=TestSpecialMetadata/1.0
ADDON_USER_AGENT_TMDB=TestTMDB/1.0
ADDON_USER_AGENT_TRIAGE=TestTriage/1.0
EOF

# Test Easynews
node -e "
require('dotenv').config();
const externalApi = require('./src/utils/externalApi');
externalApi.get('https://httpbin.org/headers', { service: 'easynews' })
  .then(r => console.log('Easynews UA:', r.data.headers['User-Agent']))
  .catch(e => console.error(e.message));
"

# Test Indexer
node -e "
require('dotenv').config();
const externalApi = require('./src/utils/externalApi');
externalApi.get('https://httpbin.org/headers', { service: 'indexer' })
  .then(r => console.log('Indexer UA:', r.data.headers['User-Agent']))
  .catch(e => console.error(e.message));
"

# Test Newznab
node -e "
require('dotenv').config();
const externalApi = require('./src/utils/externalApi');
externalApi.get('https://httpbin.org/headers', { service: 'newznab' })
  .then(r => console.log('Newznab UA:', r.data.headers['User-Agent']))
  .catch(e => console.error(e.message));
"

# Test NZBDav
node -e "
require('dotenv').config();
const externalApi = require('./src/utils/externalApi');
externalApi.get('https://httpbin.org/headers', { service: 'nzbdav' })
  .then(r => console.log('NZBDav UA:', r.data.headers['User-Agent']))
  .catch(e => console.error(e.message));
"

# Test Special Metadata
node -e "
require('dotenv').config();
const externalApi = require('./src/utils/externalApi');
externalApi.get('https://httpbin.org/headers', { service: 'specialmetadata' })
  .then(r => console.log('SpecialMetadata UA:', r.data.headers['User-Agent']))
  .catch(e => console.error(e.message));
"

# Test TMDB
node -e "
require('dotenv').config();
const externalApi = require('./src/utils/externalApi');
externalApi.get('https://httpbin.org/headers', { service: 'tmdb' })
  .then(r => console.log('TMDB UA:', r.data.headers['User-Agent']))
  .catch(e => console.error(e.message));
"

# Test Triage
node -e "
require('dotenv').config();
const externalApi = require('./src/utils/externalApi');
externalApi.get('https://httpbin.org/headers', { service: 'triage' })
  .then(r => console.log('Triage UA:', r.data.headers['User-Agent']))
  .catch(e => console.error(e.message));
"

# ------ Test in Stremio environment ------

# Install cloudflared
brew install cloudflared

# Start your server
node server.js

# Start cloudflared tunnel
cloudflared tunnel --url http://localhost:7000

# Configure usenetstreamer using the public URL provided by cloudflared

# In Stremio, add the addon using the public URL provided by cloudflared
```