### PR TITLE
Add log rotation to Docker deployment examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@
 mkdir -p ~/usenetstreamer-config
 docker run -d --restart unless-stopped \
   --name usenetstreamer \
+  --log-opt max-size=10m \
+  --log-opt max-file=1 \
   -p 7000:7000 \
   -e ADDON_SHARED_SECRET=super-secret-token \
   -e CONFIG_DIR=/data/config \
@@ -116,6 +118,11 @@ services:
     restart: unless-stopped
     ports:
       - "7000:7000"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "1"
     environment:
       ADDON_SHARED_SECRET: super-secret-token
       CONFIG_DIR: /data/config


### PR DESCRIPTION
__This is necessary due to BUG #48__

Currently, the Docker deployment examples (both docker run and docker compose) use default logging settings. Because UsenetStreamer lacks a debugging flag, console logging is effectively "always on" and unconditional.

As a result, the Docker log files grow indefinitely until they consume all available host disk space. This leads to system crashes on long-running instances or small VPS environments where disk space is limited.

This PR updates the documentation to include log rotation by default.

__Changes:__
- Docker Run: Added --log-opt max-size=10m and --log-opt max-file=1.

- Docker Compose: Added a logging block with identical limits.

These settings cap the log footprint (1 active file + 1 backup), providing enough history for debugging while preventing disk exhaustion.