### PR TITLE
Fix newznab api searches

### DIFF
--- a/src/services/newznab.js
+++ b/src/services/newznab.js
@@ -316,14 +316,6 @@ function filterUsableConfigs(configs = [], { requireEnabled = true, requireApiKe
   });
 }
 
-function mapPlanType(planType) {
-  const normalized = (planType || '').toString().toLowerCase();
-  if (normalized === 'movie' || normalized === 'tvsearch' || normalized === 'search') {
-    return normalized;
-  }
-  return 'search';
-}
-
 function applyTokenToParams(token, params) {
   if (!token || typeof token !== 'string') return;
   const match = token.match(/^\{([^:]+):(.*)\}$/);
@@ -355,9 +347,37 @@ function applyTokenToParams(token, params) {
 }
 
 function buildSearchParams(plan) {
-  const params = {
-    t: mapPlanType(plan?.type),
-  };
+  const params = {};
+  
+  // Determine if this is an ID-based search (has imdbid, tmdbid, or tvdbid tokens)
+  const hasIdToken = Array.isArray(plan?.tokens) && plan.tokens.some(token => {
+    const match = token?.match(/^\{([^:]+):/);
+    return match && ['imdbid', 'tmdbid', 'tvdbid'].includes(match[1].trim().toLowerCase());
+  });
+  
+  // For movie/TV searches:
+  // - Use t=movie/tvsearch ONLY if we have ID tokens (imdbid, tmdbid, tvdbid)
+  // - Otherwise use t=search with category filters (Newznab standard: https://newznab.readthedocs.io/en/latest/misc/api.html#predefined-categories)
+  // Movies = Category 2000
+  // TV     = Category 5000
+  if (plan?.type === 'movie') {
+    if (hasIdToken) {
+      params.t = 'movie';
+    } else {
+      params.t = 'search';
+      params.cat = '2000';
+    }
+  } else if (plan?.type === 'tvsearch') {
+    if (hasIdToken) {
+      params.t = 'tvsearch';
+    } else {
+      params.t = 'search';
+      params.cat = '5000';
+    }
+  } else {
+    params.t = 'search';
+  }
+  
   if (Array.isArray(plan?.tokens)) {
     plan.tokens.forEach((token) => applyTokenToParams(token, params));
   }


### PR DESCRIPTION
__The Issue:__

 - When no ID is provided, API calls were using non-standard search parameters with t=movie or t=tvsearch endpoints. This resulted in inconsistent or off-category results being returned by Newznab indexers.

__The Fix:__

 - Text-based Newznab searches now use t=search with category filters instead of t=movie or t=tvsearch
 - ID-based searches continue to use t=movie or t=tvsearch without category filters
 - Removed unused mapPlanType helper function
 
__The Why:__

 - Aligns with Newznab API best practices: 
     - t=movie and t=tvsearch expect ID parameters. Without them, text queries on those endpoints return inconsistent or irrelevant results
 - Matches Prowlarr's implementation: 
     - when no ID parameters are present, Prowlarr falls back to t=search and applies category filters to scope results correctly

You can test and start using these changes here:
```
ghcr.io/dsmart33/usenetstreamer:latest
```

__References:__

Newznab API Standard: 
[https://newznab.readthedocs.io/en/latest/misc/api.html#predefined-categories](https://newznab.readthedocs.io/en/latest/misc/api.html#predefined-categories
)

Prowlarr NewznabRequestGenerator: 
[https://github.com/Prowlarr/Prowlarr/blob/develop/src/NzbDrone.Core/Indexers/Definitions/Newznab/NewznabRequestGenerator.cs](https://github.com/Prowlarr/Prowlarr/blob/develop/src/NzbDrone.Core/Indexers/Definitions/Newznab/NewznabRequestGenerator.cs)

Prowlarr NewznabStandardCategory: 
[https://github.com/Prowlarr/Prowlarr/blob/develop/src/NzbDrone.Core/Indexers/NewznabStandardCategory.cs](https://github.com/Prowlarr/Prowlarr/blob/develop/src/NzbDrone.Core/Indexers/NewznabStandardCategory.cs)