### PR TITLE
fix: resolve broken strict title matching for TV series searches

### DIFF
--- a/server.js
+++ b/server.js
@@ -2243,8 +2243,8 @@ async function streamHandler(req, res) {
         const candidateTitle = (annotated?.parsedTitle || annotated?.title || annotated?.Title || '').trim();
         const strictTitlePhrase = (() => {
           try {
-            const parsed = parseTorrentTitle(plan.query || plan.strictPhrase);
-            if (parsed?.title) return sanitizeStrictSearchPhrase(parsed.title);
+            const parsed = parseReleaseMetadata(plan.query || plan.strictPhrase);
+            if (parsed?.parsedTitle) return sanitizeStrictSearchPhrase(parsed.parsedTitle);
           } catch (_) { /* fallback */ }
           return plan.strictPhrase;
         })();


### PR DESCRIPTION
The `parseTorrentTitle` function was called but never imported in server.js,
causing a silent ReferenceError in the strict text matching filter. This made
the fallback compare full search queries (e.g. "high potential s02e04") against
parsed titles (e.g. "High Potential") — guaranteed mismatch, dropping all results.

Replaced with the already-imported `parseReleaseMetadata` and its correct
`.parsedTitle` field, so the strict match now correctly compares title-only
against title-only.

Before: "High Potential S02E04" → 14 results found, 0 returned
After:  "High Potential S02E04" → 14 results found, 14 returned