### PR TITLE
feat: 7z deep inspection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM node:20-alpine
 # Set working directory inside container
 WORKDIR /usr/src/app
 
+# Install system dependencies for archive inspection and video verification
+RUN apk add --no-cache p7zip ffmpeg
+
 # Install dependencies
 COPY package*.json ./
 RUN npm ci --omit=dev


### PR DESCRIPTION
Adds the ability to check 7z file contents to ensure it contains valid media. Will return green verified check result instead of unverified.

- Creates a sparse file using the very first and very last articles of the 7z set.
- Checks contents against common list of media formats
- Performs a quick ffprobe check on the extracted file