### PR TITLE
fix: prioritize X-Addon-Token header over Authorization header

### DIFF
--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -57,7 +57,7 @@ function extractTokenFromRequest(req) {
   if (req.params && typeof req.params.token === 'string') {
     return req.params.token.trim();
   }
-  const authHeader = req.headers['authorization'] || req.headers['x-addon-token'];
+  const authHeader = req.headers['x-addon-token'] || req.headers['authorization'];
   if (typeof authHeader === 'string') {
     const parts = authHeader.split(' ');
     if (parts.length === 2 && /^token$/i.test(parts[0])) {


### PR DESCRIPTION
extractTokenFromRequest() checks the `authorization` header before `x-addon-token`. When a reverse proxy (e.g. Traefik with BasicAuth middleware) injects an `Authorization: Basic ...` header, the BasicAuth string is picked up instead of the actual addon token, causing 401 on admin API calls.

This swaps the priority so `x-addon-token` is checked first. 