### PR TITLE
Fix tmdb/tvdb index off by one in season/episode parsing

### DIFF
--- a/src/utils/parsers.js
+++ b/src/utils/parsers.js
@@ -27,11 +27,14 @@ function parseRequestedEpisode(type, id, query = {}) {
 
   const rawId = String(id || '');
   const parts = rawId.split(':');
-  const season = parts[1] ? Number(parts[1]) : null;
-  const episode = parts[2] ? Number(parts[2]) : null;
 
-  if (Number.isFinite(season) && Number.isFinite(episode)) {
-    return { season, episode };
+  // Use the last two segments as season and episode (handles tmdb:<id>:S:E).
+  if (parts.length >= 2) {
+    const season = Number(parts[parts.length - 2]);
+    const episode = Number(parts[parts.length - 1]);
+    if (Number.isFinite(season) && Number.isFinite(episode)) {
+      return { season, episode };
+    }
   }
 
   if (query.season !== undefined && query.episode !== undefined) {


### PR DESCRIPTION
When there is no IMDB ID available usenetstreamer will try to parse episode and request id in the wrong way, it will always take the second and third element for season/episode respectively.

For example:

`tt1190634:5:2` is parsed correctly (season 5 episode 2)
`tmdb:76479:5:2` is not (it will use season 76479 and episode 5)

With tmdb/tvdb the indices are shifted by one. To fix this in general let's just use the last two indices instead.

Not sure how the IDs look for other providers but at least this works for imdb/tmdb/tvdb.