### PR TITLE
Don't call toLowerCase on number

### DIFF
--- a/server.js
+++ b/server.js
@@ -2174,7 +2174,7 @@ async function streamHandler(req, res) {
 
       const resultMatchesStrictPlan = (plan, item) => {
         const isTvdbPlan = Array.isArray(plan?.tokens) && plan.tokens.some(t => /^\{TvdbId:/i.test(t));
-        const isSceneNzbs = (item?.indexerId || item?.indexer || '').toLowerCase().includes('scenenzbs');
+        const isSceneNzbs = String(item?.indexerId || item?.indexer || '').toLowerCase().includes('scenenzbs');
         if (isTvdbPlan && isSceneNzbs && type === 'series' && Number.isFinite(seasonNum) && Number.isFinite(episodeNum)) {
           const annotated = (item?.season !== undefined || item?.episode !== undefined) ? item : annotateNzbResult(item, 0);
           if (Number(annotated?.season) !== Number(seasonNum) || Number(annotated?.episode) !== Number(episodeNum)) return false;


### PR DESCRIPTION
- Let's convert the indexer ID to a string before calling toLowerCase on it.
- This is needed when using Prowlarr as indexer aggregator as Prowlarr uses numeric IDs.

```
[SEARCH mgr=PROWLARR direct=OFF] Using configured indexers [ '3', '2', '33', '32' ]                                                                                                                   
[SEARCH mgr=PROWLARR direct=OFF] ID-based searches completed in 4633 ms total                                                                                                                         
[SEARCH mgr=PROWLARR direct=OFF] ID plan execution time: 4633 ms for "{TvdbId:355567} {Season:5} {Episode:2}"                                                                                         
[SEARCH mgr=PROWLARR direct=OFF] ✅ tvsearch returned 166 total results for query "{TvdbId:355567} {Season:5} {Episode:2}" { managerCount: 166, newznabCount: 0, errors: undefined }                  
[ERROR] Processing failed: ((intermediate value) || (intermediate value) || "").toLowerCase is not a function 
```