### PR TITLE
feat(catalog): enrich NZBDav catalog/meta with TMDb titles & posters

### DIFF
--- a/src/routes/buildNzbdavMeta.js
+++ b/src/routes/buildNzbdavMeta.js
@@ -1,0 +1,172 @@
+const { parseReleaseMetadata } = require('../services/metadata/releaseParser');
+const tmdbService = require('../services/tmdb');
+
+function fallbackMeta(entry, type, addonBaseUrl) {
+  return {
+    id: `nzbdav:${entry.nzoId}`,
+    type,
+    name: entry?.jobName || 'NZBDav Completed',
+    poster: `${(addonBaseUrl || '').replace(/\/$/, '')}/assets/icon.png`,
+  };
+}
+
+// Episode releases share a show title in TMDb, so a series catalog enriched
+// to "The Bear" / "The Bear" / "The Bear" hides the per-episode identity that
+// the raw jobName carried. Append SxxEyy when the parser surfaces it.
+function formatEnrichedSeriesName(tmdbTitle, parsed) {
+  if (!tmdbTitle) return null;
+  const season = Number.isFinite(parsed?.season) ? parsed.season : null;
+  const episode = Number.isFinite(parsed?.episode) ? parsed.episode : null;
+  if (season === null || episode === null) return tmdbTitle;
+  const ss = String(season).padStart(2, '0');
+  const ee = String(episode).padStart(2, '0');
+  return `${tmdbTitle} S${ss}E${ee}`;
+}
+
+/**
+ * Build a Stremio-shaped meta object for an NZBDav history entry, enriching
+ * the display name and poster from TMDb when an API key is configured. Falls
+ * back to the addon icon and the raw jobName otherwise.
+ *
+ * @param {object} entry - nzbdav history entry { nzoId, jobName, ... }
+ * @param {string} type - 'movie' or 'series'
+ * @param {string} addonBaseUrl - ADDON_BASE_URL (used for the fallback poster)
+ * @returns {Promise<object>} Stremio meta { id, type, name, poster }
+ */
+async function buildNzbdavMeta(entry, type, addonBaseUrl) {
+  const meta = fallbackMeta(entry, type, addonBaseUrl);
+
+  if (!entry?.jobName || !tmdbService.isConfigured()) {
+    return meta;
+  }
+
+  const parsed = parseReleaseMetadata(entry.jobName);
+  const searchTitle = parsed?.parsedTitle || null;
+  if (!searchTitle) {
+    return meta;
+  }
+
+  const tmdbMatch = await tmdbService.searchByTitle({
+    title: searchTitle,
+    type,
+    year: Number.isFinite(parsed?.year) ? parsed.year : null,
+  });
+
+  if (!tmdbMatch) {
+    return meta;
+  }
+
+  const enrichedName =
+    type === 'series'
+      ? formatEnrichedSeriesName(tmdbMatch.title, parsed) || meta.name
+      : tmdbMatch.title || meta.name;
+
+  return {
+    ...meta,
+    name: enrichedName,
+    poster: tmdbMatch.posterUrl || meta.poster,
+  };
+}
+
+/**
+ * Single-item variant of buildNzbdavMeta with a soft time budget. Used by the
+ * meta endpoint so a slow or unreachable TMDb cannot stall the response past
+ * client/proxy timeouts. Falls back to the plain meta on deadline.
+ *
+ * @param {object} entry
+ * @param {string} type
+ * @param {string} addonBaseUrl
+ * @param {object} [options]
+ * @param {number} [options.timeBudgetMs=3000]
+ * @returns {Promise<object>}
+ */
+async function buildNzbdavMetaWithDeadline(
+  entry,
+  type,
+  addonBaseUrl,
+  { timeBudgetMs = 3000 } = {}
+) {
+  if (!tmdbService.isConfigured()) {
+    return buildNzbdavMeta(entry, type, addonBaseUrl);
+  }
+
+  let timer;
+  const timeoutPromise = new Promise((resolve) => {
+    timer = setTimeout(() => resolve(fallbackMeta(entry, type, addonBaseUrl)), timeBudgetMs);
+  });
+
+  try {
+    return await Promise.race([
+      buildNzbdavMeta(entry, type, addonBaseUrl).catch(() => fallbackMeta(entry, type, addonBaseUrl)),
+      timeoutPromise,
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Build metas for a list of NZBDav entries.
+ *
+ * Returns immediately-usable fallback metas, then enriches each one with
+ * TMDb data subject to two limits: a worker pool to bound parallel TMDb
+ * traffic, and a soft time budget so a slow or unreachable TMDb cannot
+ * stall the catalog response. Items still in flight at the deadline keep
+ * running in the background — they warm the TMDb cache for subsequent
+ * requests but do not block the current response.
+ *
+ * @param {Array<object>} entries
+ * @param {string} type - 'movie' or 'series'
+ * @param {string} addonBaseUrl
+ * @param {object} [options]
+ * @param {number} [options.concurrency=5]
+ * @param {number} [options.timeBudgetMs=4000]
+ * @returns {Promise<Array<object>>}
+ */
+async function buildNzbdavMetas(
+  entries,
+  type,
+  addonBaseUrl,
+  { concurrency = 5, timeBudgetMs = 4000 } = {}
+) {
+  if (!Array.isArray(entries) || entries.length === 0) return [];
+
+  const results = entries.map((entry) => fallbackMeta(entry, type, addonBaseUrl));
+
+  if (!tmdbService.isConfigured()) return results;
+
+  const workerCount = Math.max(1, Math.min(concurrency, entries.length));
+  let cursor = 0;
+
+  const enrichmentPromise = (async () => {
+    const workers = Array.from({ length: workerCount }, async () => {
+      while (cursor < entries.length) {
+        const index = cursor++;
+        try {
+          results[index] = await buildNzbdavMeta(entries[index], type, addonBaseUrl);
+        } catch (_error) {
+          // Keep the fallback meta on enrichment failure
+        }
+      }
+    });
+    await Promise.all(workers);
+  })();
+
+  let timer;
+  const timeoutPromise = new Promise((resolve) => {
+    timer = setTimeout(resolve, timeBudgetMs);
+  });
+
+  try {
+    await Promise.race([enrichmentPromise, timeoutPromise]);
+  } finally {
+    clearTimeout(timer);
+  }
+
+  return results;
+}
+
+module.exports = buildNzbdavMeta;
+module.exports.buildNzbdavMeta = buildNzbdavMeta;
+module.exports.buildNzbdavMetas = buildNzbdavMetas;
+module.exports.buildNzbdavMetaWithDeadline = buildNzbdavMetaWithDeadline;

--- a/src/routes/catalog.js
+++ b/src/routes/catalog.js
@@ -1,5 +1,6 @@
 const nzbdavService = require('../services/nzbdav');
 const { sanitizeErrorForClient } = require('../utils/helpers');
+const { buildNzbdavMetas } = require('./buildNzbdavMeta');
 
 module.exports = function createCatalogHandler(getConfig) {
   return async function catalogHandler(req, res) {
@@ -34,17 +35,8 @@ module.exports = function createCatalogHandler(getConfig) {
     const historyMap = await nzbdavService.fetchCompletedNzbdavHistory([categoryForType], limit + skip);
     const entries = Array.from(historyMap.values());
     const slice = entries.slice(skip, skip + limit);
-    const poster = `${ADDON_BASE_URL.replace(/\/$/, '')}/assets/icon.png`;
 
-    const metas = slice.map((entry) => {
-      const name = entry.jobName || 'NZBDav Completed';
-      return {
-        id: `nzbdav:${entry.nzoId}`,
-        type,
-        name,
-        poster,
-      };
-    });
+    const metas = await buildNzbdavMetas(slice, type, ADDON_BASE_URL);
 
     res.json({ metas });
   };

--- a/src/routes/meta.js
+++ b/src/routes/meta.js
@@ -1,5 +1,6 @@
 const nzbdavService = require('../services/nzbdav');
 const { sanitizeErrorForClient } = require('../utils/helpers');
+const { buildNzbdavMetaWithDeadline } = require('./buildNzbdavMeta');
 
 module.exports = function createMetaHandler(getConfig) {
   return async function metaHandler(req, res) {
@@ -37,14 +38,8 @@ module.exports = function createMetaHandler(getConfig) {
       return;
     }
 
-    const poster = `${ADDON_BASE_URL.replace(/\/$/, '')}/assets/icon.png`;
     res.json({
-      meta: {
-        id: `nzbdav:${match.nzoId}`,
-        type,
-        name: match.jobName || 'NZBDav Completed',
-        poster,
-      }
+      meta: await buildNzbdavMetaWithDeadline(match, type, ADDON_BASE_URL),
     });
   };
 };

--- a/src/services/tmdb.js
+++ b/src/services/tmdb.js
@@ -127,6 +127,23 @@ function normalizeToAscii(text) {
     .trim();
 }
 
+function normalizeSearchText(text) {
+  return String(text || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+function buildPosterUrl(posterPath, size = 'w342') {
+  if (!posterPath) return null;
+  return `https://image.tmdb.org/t/p/${size}${posterPath}`;
+}
+
+// Sentinel cached when a title search returns no usable result, so a cached
+// miss is distinguishable from "no cache entry" — getFromCache() returns null
+// for both an absent key and a value stored as null.
+const SEARCH_CACHE_MISS = Object.freeze({ __searchByTitle: 'miss' });
+
 /**
  * Get cache key for TMDb lookups
  */
@@ -349,6 +366,112 @@ async function getExternalIds(tmdbId, mediaType) {
     return parsed;
   } catch (error) {
     console.error(`[TMDB] getExternalIds error for ${mediaType}/${tmdbId}:`, error.message);
+    return null;
+  }
+}
+
+/**
+ * Search TMDb by title (with optional year) and return the best-ranked match.
+ * Used for catalog/meta enrichment when the only handle on a release is its
+ * parsed jobName.
+ *
+ * @param {object} options
+ * @param {string} options.title - parsed release title
+ * @param {string} options.type - 'movie' or 'series'
+ * @param {number|null} [options.year] - release year (movie) or first-air year (tv)
+ * @returns {Promise<object|null>} { tmdbId, mediaType, title, originalTitle, releaseYear, posterPath, posterUrl, backdropPath } or null
+ */
+async function searchByTitle({ title, type, year = null }) {
+  if (!isConfigured()) {
+    return null;
+  }
+
+  const trimmedTitle = String(title || '').trim();
+  if (!trimmedTitle) {
+    return null;
+  }
+
+  const mediaType = type === 'series' ? 'tv' : 'movie';
+  const cacheKey = getCacheKey('search', `${mediaType}:${trimmedTitle.toLowerCase()}:${year || ''}`, null);
+  const cached = getFromCache(cacheKey);
+  if (cached === SEARCH_CACHE_MISS) {
+    return null;
+  }
+  if (cached !== null) {
+    return cached;
+  }
+
+  try {
+    const endpoint = mediaType === 'movie' ? '/search/movie' : '/search/tv';
+    const params = {
+      query: trimmedTitle,
+      include_adult: false,
+      language: 'en-US',
+    };
+
+    if (Number.isFinite(year)) {
+      if (mediaType === 'movie') {
+        params.year = String(year);
+      } else {
+        params.first_air_date_year = String(year);
+      }
+    }
+
+    const data = await tmdbRequest(endpoint, params);
+    const results = Array.isArray(data?.results) ? data.results : [];
+    if (results.length === 0) {
+      setInCache(cacheKey, SEARCH_CACHE_MISS);
+      return null;
+    }
+
+    const normalizedQuery = normalizeSearchText(trimmedTitle);
+    const ranked = results
+      .slice(0, 10)
+      .map((result, index) => {
+        const primaryTitle = result?.title || result?.name || '';
+        const originalTitle = result?.original_title || result?.original_name || '';
+        const normalizedPrimary = normalizeSearchText(primaryTitle);
+        const normalizedOriginal = normalizeSearchText(originalTitle);
+        const resultYear = Number.parseInt(String(result?.release_date || result?.first_air_date || '').slice(0, 4), 10);
+        let score = 0;
+
+        if (normalizedPrimary === normalizedQuery || normalizedOriginal === normalizedQuery) {
+          score += 100;
+        } else if (normalizedPrimary.includes(normalizedQuery) || normalizedOriginal.includes(normalizedQuery)) {
+          score += 50;
+        }
+
+        if (Number.isFinite(year) && Number.isFinite(resultYear) && resultYear === year) {
+          score += 20;
+        }
+
+        score += Math.max(0, 10 - index);
+
+        return { result, score };
+      })
+      .sort((left, right) => right.score - left.score);
+
+    const best = ranked[0]?.result;
+    if (!best) {
+      setInCache(cacheKey, SEARCH_CACHE_MISS);
+      return null;
+    }
+
+    const parsed = {
+      tmdbId: String(best.id),
+      mediaType,
+      title: best.title || best.name || trimmedTitle,
+      originalTitle: best.original_title || best.original_name || null,
+      releaseYear: (best.release_date || best.first_air_date || '').substring(0, 4) || null,
+      posterPath: best.poster_path || null,
+      posterUrl: buildPosterUrl(best.poster_path),
+      backdropPath: best.backdrop_path || null,
+    };
+
+    setInCache(cacheKey, parsed);
+    return parsed;
+  } catch (error) {
+    console.error(`[TMDB] searchByTitle error for ${trimmedTitle}:`, error.message);
     return null;
   }
 }
@@ -653,6 +776,7 @@ module.exports = {
   findByExternalId,
   getDetails,
   getExternalIds,
+  searchByTitle,
   getMetadataAndTitles,
   getLocalizedTitle,
   normalizeToAscii,


### PR DESCRIPTION
## Summary

When `TMDB_API_KEY` is configured, this populates the **NZBDav completed**
catalog/meta entries with real titles and posters from TMDb instead of the
raw release name and the addon icon.

When TMDb is **not** configured — or the parser can't extract a title, or
TMDb returns no match — the response is byte-identical to the existing
behavior (raw `jobName` + `assets/icon.png`).

## What changed

- **`src/services/tmdb.js`** — new `searchByTitle({ title, type, year })`:
  - Scores TMDb candidates: exact normalized match > substring; year tiebreak; result-list-position tiebreak.
  - Caches both hits and misses (uses a sentinel object so cached `null` is distinguishable from "no entry").

- **`src/routes/buildNzbdavMeta.js`** — new shared helper used by both routes:
  - `buildNzbdavMeta(entry, type, baseUrl)` — single-entry enrichment.
  - `buildNzbdavMetas(entries, type, baseUrl)` — catalog batch with a **5-wide worker pool** and a **4s soft deadline**. Items still in flight at the deadline keep running in the background to warm the cache for the next request, but do not block the response.
  - `buildNzbdavMetaWithDeadline(entry, type, baseUrl)` — single-item variant for the meta route with a **3s soft deadline** so a slow/unreachable TMDb cannot stall past typical client/proxy timeouts.

- **`src/routes/catalog.js`** / **`src/routes/meta.js`** — delegate to the shared helper.

## Behavior matrix

| TMDB configured | Match found | Catalog/meta result |
|---|---|---|
| no | n/a | unchanged: raw `jobName` + addon icon |
| yes | yes (movie) | TMDb title + TMDb poster |
| yes | yes (series) | TMDb title with `SxxEyy` appended (so episodes stay distinguishable) + TMDb poster |
| yes | no | unchanged fallback (cached as a miss to avoid re-querying) |
| yes, but slow | n/a | catalog returns whatever enriched in the budget + fallbacks for the rest; meta returns fallback if not enriched in time |

## Notes

- TMDb language is hardcoded to `en-US` for v1 — happy to thread the user's preferred locale through in a follow-up.
- Series enrichment intentionally appends `SxxEyy` rather than fetching per-episode metadata; per-episode enrichment would require an additional TMDb call per item, which the time budget cannot easily absorb.
- Reviewed via codex; clean.

## Test plan

- [x] `node --check` on all modified files
- [x] Smoke test: with no API key, fallback shape matches existing output exactly
- [x] Smoke test: bounded-concurrency mapper preserves order and respects the time budget
- [x] Smoke test: negative results are cached (zero re-queries on repeat title)
- [x] Smoke test: series episodes from the same show remain distinguishable post-enrichment
- [x] Smoke test: `buildNzbdavMetaWithDeadline` returns the fallback when TMDb is slower than the budget
- [ ] Manual verification with a live TMDB key + populated NZBDav history